### PR TITLE
Remove IAM bindings for members

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@ resource "google_storage_bucket" "bucket" {
   }
 }
 
-resource "google_storage_bucket_iam_binding" "bindings" {
+resource "google_storage_bucket_iam_member" "members" {
   for_each = var.iam
   bucket   = google_storage_bucket.bucket.name
   role     = each.key

--- a/main.tf
+++ b/main.tf
@@ -10,8 +10,8 @@ locals {
     for role_name, members in var.iam : {
       for member in members :
           "${role_name}-${member}" => {
-            role_name = rolename
-            member    =  member
+            role_name = role_name
+            member    = member
           }
     }
    ])

--- a/main.tf
+++ b/main.tf
@@ -75,7 +75,7 @@ resource "google_storage_bucket_iam_member" "members" {
   for_each = var.iam
   bucket   = google_storage_bucket.bucket.name
   role     = each.key
-  members  = each.value
+  member   = each.value
 }
 
 resource "google_project_iam_member" "transfer_buckets_list" {

--- a/main.tf
+++ b/main.tf
@@ -8,13 +8,13 @@ locals {
   security_prefix = "${lower(substr(local.name_title, 0, 1))}${substr(local.name_title, 1, 120)}"
   iam_roles = merge([
     for role_name, members in var.iam : {
-      for member in members :
+      for member in members : 
           "${role_name}-${member}" => {
             role_name = role_name
             member    = member
           }
     }
-   ])
+   ]...)
 }
 
 resource "google_storage_bucket" "bucket" {

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ locals {
   name_title = replace(title(var.name), "-", "")
   security_prefix = "${lower(substr(local.name_title, 0, 1))}${substr(local.name_title, 1, 120)}"
   iam_roles = merge([
-    for role_name, members in local.iam : {
+    for role_name, members in var.iam : {
       for member in members :
           "${role_name}-${member}" => {
             role_name = rolename


### PR DESCRIPTION
This removes authoritative, atomic IAM bindings for non-authoritative members, which is simply more friendly and removes group membership thrashing on every apply.